### PR TITLE
If post has no description, use the summary instead

### DIFF
--- a/layouts/partials/posts/featured.html
+++ b/layouts/partials/posts/featured.html
@@ -7,7 +7,11 @@
         <span class="date">{{ .Date.Format (.Site.Params.DateFormat | default "January 2, 2006") }}</span>
         {{ end }}
         <h2><a href="{{ .Permalink }}">{{ .Title }}</a></h2>
+        {{ if .Description }}
         <p>{{ .Description }}</p>
+        {{ else }}
+        <p>{{ .Summary }}</p>
+        {{ end }}
     </header>
     {{ if .Params.image }}
     <a href="{{ .Permalink }}" class="image main"><img src="{{ .Params.image | relURL }}" alt="" /></a>

--- a/layouts/partials/posts/list.html
+++ b/layouts/partials/posts/list.html
@@ -12,7 +12,11 @@
         {{ if .Params.image }}
         <a href="{{ .Permalink }}" class="image fit"><img src="{{ .Params.image | relURL }}" alt="" /></a>
         {{ end }}
+        {{ if .Description }}
         <p>{{ .Description }}</p>
+        {{ else }}
+        <p>{{ .Summary }}</p>
+        {{ end }}
         <ul class="actions">
             <li><a href="{{ .Permalink }}" class="button">{{ $data.post.linktext }}</a></li>
         </ul>


### PR DESCRIPTION
The summary is [generated automatically](https://gohugo.io/content-management/summaries/) by hugo.
This could make transitioning to massively from a theme that
doesn't require descriptions of posts much easier.